### PR TITLE
Mc compiler warnings due to int uint comparisons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 
-
 install:
   - conda create --yes -n pelenv python=$TRAVIS_PYTHON_VERSION nose pip cython numpy scipy matplotlib qt pyqt
   - source activate pelenv


### PR DESCRIPTION
There was some conflict with the travis file, but that is solved and it is the same as in the master repository.
