### PR TITLE
do not modify ranvec input in constructor

### DIFF
--- a/source/mcpele/lowest_eigenvalue.cpp
+++ b/source/mcpele/lowest_eigenvalue.cpp
@@ -6,9 +6,9 @@ namespace mcpele{
 
 
 FindLowestEigenvalue::FindLowestEigenvalue(std::shared_ptr<pele::BasePotential> landscape_potential, const size_t boxdimension,
-        pele::Array<double> ranvec, const size_t lbfgsniter)
+        const pele::Array<double> ranvec, const size_t lbfgsniter)
     : _lowesteigpot(std::make_shared<pele::LowestEigPotential>(landscape_potential, ranvec.copy(), boxdimension)),
-      _ranvec((ranvec /= norm(ranvec)).copy()),
+      _ranvec((ranvec.copy() /= norm(ranvec))),
       _lbfgs(_lowesteigpot, _ranvec.copy())
 {
     if (isinf(double(1) / norm(ranvec))) {

--- a/source/mcpele/lowest_eigenvalue.h
+++ b/source/mcpele/lowest_eigenvalue.h
@@ -15,7 +15,7 @@ private:
     pele::LBFGS _lbfgs;
 public:
     FindLowestEigenvalue(std::shared_ptr<pele::BasePotential> landscape_potential, const size_t boxdimension,
-            pele::Array<double> ranvec, const size_t lbfgsniter);
+            const pele::Array<double> ranvec, const size_t lbfgsniter);
     double compute_lowest_eigenvalue(pele::Array<double> coords);
 };
 


### PR DESCRIPTION
Bug fix for FindLowestEigenvalue constructor.
Now ranvec is not changed by the constructor.
This is better for most applications because the arrays are passed on by reference.
