### PR TITLE
change ConfTest test function name from test to conf_test

### DIFF
--- a/cpp_tests/source/test_conf_tests.cpp
+++ b/cpp_tests/source/test_conf_tests.cpp
@@ -19,7 +19,7 @@ TEST(CheckSphericalContainer, Works){
 
     mcpele::CheckSphericalContainer check(r, ndim);
     x[0] = r - eps;
-    EXPECT_TRUE(check.test(x, mcvoid));
+    EXPECT_TRUE(check.conf_test(x, mcvoid));
     x[0] = r + eps;
-    EXPECT_FALSE(check.test(x, mcvoid));
+    EXPECT_FALSE(check.conf_test(x, mcvoid));
 }

--- a/cpp_tests/source/test_mc.cpp
+++ b/cpp_tests/source/test_mc.cpp
@@ -121,7 +121,7 @@ struct TrivialConfTest : public mcpele::ConfTest{
         : return_val(return_val1), call_count(0)
     {}
 
-    virtual bool test(Array<double> &trial_coords, mcpele::MC * mc)
+    virtual bool conf_test(Array<double> &trial_coords, mcpele::MC * mc)
     {
         call_count++;
         return return_val;

--- a/source/mcpele/conf_test.cpp
+++ b/source/mcpele/conf_test.cpp
@@ -11,7 +11,7 @@ CheckSphericalContainer::CheckSphericalContainer(double radius, size_t ndim)
     //std::cout << "construct CheckSphericalContainer" <<  "\n";
 }
 
-bool CheckSphericalContainer::test(Array<double> &trial_coords, MC * mc)
+bool CheckSphericalContainer::conf_test(Array<double> &trial_coords, MC * mc)
 {
   size_t N = trial_coords.size();
 

--- a/source/mcpele/conf_test.h
+++ b/source/mcpele/conf_test.h
@@ -24,7 +24,7 @@ protected:
 public:
 
     CheckSphericalContainer(double radius, size_t ndim);
-    virtual bool test(Array<double> &trial_coords, MC * mc);
+    virtual bool conf_test(Array<double> &trial_coords, MC * mc);
     virtual ~CheckSphericalContainer(){}
 };
 

--- a/source/mcpele/mc.cpp
+++ b/source/mcpele/mc.cpp
@@ -34,7 +34,7 @@ bool MC::do_conf_tests(Array<double> x)
 {
     bool result;
     for (auto & test : _conf_tests){
-        result = test->test(x, this);
+        result = test->conf_test(x, this);
         if (not result){
             ++_conf_reject_count;
             return false;
@@ -66,7 +66,7 @@ bool MC::do_late_conf_tests(Array<double> x)
 {
     bool result;
     for (auto & test : _late_conf_tests){
-        result = test->test(x, this);
+        result = test->conf_test(x, this);
         if (not result){
             ++_conf_reject_count;
             return false;

--- a/source/mcpele/mc.h
+++ b/source/mcpele/mc.h
@@ -56,7 +56,7 @@ public:
     //ConfTest(){std::cout << "ConfTest()" <<  "\n";}
     //virtual ~ConfTest(){std::cout << "~ConfTest()" <<  "\n";}
     virtual ~ConfTest(){}
-    virtual bool test(Array<double> &trial_coords, MC * mc) =0;
+    virtual bool conf_test(Array<double> &trial_coords, MC * mc) =0;
 };
 
 /*


### PR DESCRIPTION
Address issue #3 by changing test function name of ConfTest.
Changes in cpp tests for consistency.
