### PR TITLE
Unused parameter warnings

### DIFF
--- a/source/adaptive_takestep.cpp
+++ b/source/adaptive_takestep.cpp
@@ -14,9 +14,8 @@ AdaptiveTakeStep::AdaptiveTakeStep(std::shared_ptr<TakeStep> ts,
       m_max_acceptance_ratio(max_acceptance_ratio)
 {}
 
-void AdaptiveTakeStep::report(__attribute__((unused)) pele::Array<double>& old_coords,
-        __attribute__((unused)) const double old_energy, __attribute__((unused)) pele::Array<double>& new_coords,
-        __attribute__((unused)) const double new_energy, const bool success, MC* mc)
+void AdaptiveTakeStep::report(pele::Array<double>&, const double,
+        pele::Array<double>&, const double, const bool success, MC* mc)
 {
     ++m_total_steps;
     if (success) {

--- a/source/energy_window_test.cpp
+++ b/source/energy_window_test.cpp
@@ -11,9 +11,8 @@ EnergyWindowTest::EnergyWindowTest(const double min_energy, const double max_ene
       m_max_energy(max_energy)
 {}
 
-bool EnergyWindowTest::test(__attribute__((unused)) Array<double> &trial_coords, double trial_energy,
-        __attribute__((unused)) Array<double> & old_coords, __attribute__((unused)) double old_energy,
-        __attribute__((unused)) double temperature, __attribute__((unused)) MC * mc)
+bool EnergyWindowTest::test(Array<double>&, double trial_energy,
+        Array<double>&, double, double, MC*)
 {
     return ((trial_energy >= m_min_energy) and (trial_energy <= m_max_energy));
 }

--- a/source/mcpele/mc.h
+++ b/source/mcpele/mc.h
@@ -60,14 +60,10 @@ class TakeStep {
 public:
     virtual ~TakeStep() {}
     virtual void displace(pele::Array<double>& coords, MC* mc) = 0;
-    virtual void report(__attribute__((unused)) pele::Array<double>& old_coords,
-            __attribute__((unused)) const double old_energy,
-            __attribute__((unused)) pele::Array<double>& new_coords,
-            __attribute__((unused)) const double new_energy,
-            __attribute__((unused)) const bool success,
-            __attribute__((unused)) MC* mc) {}
-    virtual void increase_acceptance(__attribute__((unused)) const double factor) {}
-    virtual void decrease_acceptance(__attribute__((unused)) const double factor) {}
+    virtual void report(pele::Array<double>&, const double,
+            pele::Array<double>&, const double, const bool, MC*) {}
+    virtual void increase_acceptance(const double) {}
+    virtual void decrease_acceptance(const double) {}
 };
 
 /**


### PR DESCRIPTION
This silences some compiler warnings about unused parameters.
There is some discussion on the issue here:
http://stackoverflow.com/questions/3599160/unused-parameter-warnings-in-c-code
It seemed fine to me to take the version that is safest but probably only works in gcc, because we are using other gcc specific features as well.
Otherwise the most general thing is apparently the macro solution.
