### PR TITLE
add check that adaptive takestep factor is in (0,1)

### DIFF
--- a/source/adaptive_takestep.cpp
+++ b/source/adaptive_takestep.cpp
@@ -12,7 +12,11 @@ AdaptiveTakeStep::AdaptiveTakeStep(std::shared_ptr<TakeStep> ts,
       m_factor(factor),
       m_min_acceptance_ratio(min_acceptance_ratio),
       m_max_acceptance_ratio(max_acceptance_ratio)
-{}
+{
+    if (factor <= 0 || factor >= 1) {
+        throw std::runtime_error("AdaptiveTakeStep::AdaptiveTakeStep: input factor has illegal value");
+    }
+}
 
 void AdaptiveTakeStep::report(pele::Array<double>& old_coords,
         const double old_energy, pele::Array<double>& new_coords,


### PR DESCRIPTION
This follows our discussion.
AdaptiveTakeStep assumes factor to be greater than 0 and less than 1 and will fail otherwise.
