### PR TITLE
fix takestep parameter value

### DIFF
--- a/examples/sfHS_WCA_fluid/radial_distribution_function.py
+++ b/examples/sfHS_WCA_fluid/radial_distribution_function.py
@@ -48,7 +48,7 @@ class ComputeGR():
         # Potential and MC rules.
         self.temperature = 1
         self.mc = MC(self.potential, self.x, self.temperature, self.nr_steps)
-        self.step = RandomCoordsDisplacement(42, 1, single=True, nparticles=1, bdim=self.boxdim)
+        self.step = RandomCoordsDisplacement(42, 1, single=True, nparticles=self.nr_particles, bdim=self.boxdim)
         if self.verbose:
             print ("initial MC stepsize")
             print self.step.get_stepsize()


### PR DESCRIPTION
This fixes the radial distribution function example.
The parameters of the take-step module were set such that only the same single particle was moved.
Now the radial distribution function looks nicer, as can be seen in the attachment.