### PR TITLE
implemented conf test union

### DIFF
--- a/mcpele/monte_carlo/__init__.py
+++ b/mcpele/monte_carlo/__init__.py
@@ -1,8 +1,9 @@
 from _accept_test_cpp import MetropolisTest
 from _conf_test_cpp import CheckSphericalContainer
-from _conf_test_cpp import CheckSphericalContainerConfig
+from _conf_test_cpp import CheckSphericalContainerConfig, ConfTestOR
 from _takestep_cpp import RandomCoordsDisplacement, SampleGaussian, GaussianCoordsDisplacement, ParticlePairSwap, TakeStepPattern, TakeStepProbabilities
 from _monte_carlo_cpp import _BaseMCRunner
 from _action_cpp import RecordEnergyHistogram, RecordEnergyTimeseries, RecordPairDistHistogram, RecordLowestEValueTimeseries, RecordDisplacementPerParticleTimeseries
 from _nullpotential_cpp import NullPotential
 from mcrunner import Metropolis_MCrunner
+

--- a/mcpele/monte_carlo/__init__.py
+++ b/mcpele/monte_carlo/__init__.py
@@ -4,6 +4,7 @@ from _conf_test_cpp import CheckSphericalContainerConfig, ConfTestOR
 from _takestep_cpp import RandomCoordsDisplacement, SampleGaussian, GaussianCoordsDisplacement, ParticlePairSwap, TakeStepPattern, TakeStepProbabilities
 from _monte_carlo_cpp import _BaseMCRunner
 from _action_cpp import RecordEnergyHistogram, RecordEnergyTimeseries, RecordPairDistHistogram, RecordLowestEValueTimeseries, RecordDisplacementPerParticleTimeseries
+from _action_cpp import RecordMeanCoordVector
 from _nullpotential_cpp import NullPotential
 from mcrunner import Metropolis_MCrunner
 

--- a/mcpele/monte_carlo/_action_cpp.pxd
+++ b/mcpele/monte_carlo/_action_cpp.pxd
@@ -50,4 +50,11 @@ cdef extern from "mcpele/record_displacement_per_particle_timeseries.h" namespac
     cdef cppclass cppRecordDisplacementPerParticleTimeseries "mcpele::RecordDisplacementPerParticleTimeseries":
         cppRecordDisplacementPerParticleTimeseries(size_t, size_t,
             _pele.Array[double], size_t) except +
-        
+
+cdef extern from "mcpele/record_mean_coord_vector.h" namespace "mcpele": 
+    cdef cppclass cppRecordMeanCoordVector "mcpele::RecordMeanCoordVector":
+        cppRecordMeanCoordVector(size_t, size_t) except +
+        _pele.Array[double] get_mean_coordinate_vector() except +
+        _pele.Array[double] get_mean2_coordinate_vector() except +
+        _pele.Array[double] get_variance_coordinate_vector() except +
+        size_t get_count() except +

--- a/mcpele/monte_carlo/_action_cpp.pyx
+++ b/mcpele/monte_carlo/_action_cpp.pyx
@@ -380,3 +380,62 @@ class RecordDisplacementPerParticleTimeseries(_Cdef_RecordDisplacementPerParticl
     boxdimension: int
         dimensionality of the space (dimensionality of box)
     """
+
+cdef class _Cdef_RecordMeanCoordVector(_Cdef_Action):
+    cdef cppRecordMeanCoordVector* newptr
+    def __cinit__(self, ndof, eqsteps):
+        self.thisptr = shared_ptr[cppAction](<cppAction*> new cppRecordMeanCoordVector(ndof, eqsteps))
+        self.newptr = <cppRecordMeanCoordVector*> self.thisptr.get()
+    
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def get_mean_variance_coordinate_vector(self):
+        """returns the mean coordinate vector
+        
+        Returns
+        -------
+        numpy.array
+            mean coordinate vector
+        numpy.array
+            element-wise variance coordinate vector
+        """
+        cdef _pele.Array[double] coordi = self.newptr.get_mean_coordinate_vector()
+        cdef _pele.Array[double] vari = self.newptr.get_variance_coordinate_vector()
+        cdef double *coorddata = coordi.data()
+        cdef double *vardata = vari.data()
+        cdef np.ndarray[double, ndim=1, mode="c"] coord = np.zeros(coordi.size())
+        cdef np.ndarray[double, ndim=1, mode="c"] var = np.zeros(vari.size())
+        cdef size_t i
+        for i in xrange(coordi.size()):
+            coord[i] = coorddata[i]
+            var[i] = vardata[i]
+        return coord, var
+
+    def get_count(self):
+        """get number of steps over which the average was computed
+        
+        Returns
+        -------
+        count : integer
+            sample size
+        """
+        count = self.newptr.get_count()
+        return count
+
+class RecordMeanCoordVector(_Cdef_RecordMeanCoordVector):
+    """Record average position during random walk
+    
+    This class is the Python interface for the c++ RecordMeanCoordVector implementation.
+    
+    .. warning :: :class:`RecordMeanCoordVector` should only start recording
+                  entries when the system is equilibrated, set the number of steps
+                  to skip with the ``eqsteps`` parameter.
+    
+    Parameters
+    ----------
+    ndof: int
+        size of coordinate vector
+    eqsteps: int
+        number of iterations to skip before starting to record entries
+        
+    """

--- a/mcpele/monte_carlo/_conf_test_cpp.pxd
+++ b/mcpele/monte_carlo/_conf_test_cpp.pxd
@@ -1,5 +1,5 @@
 from libcpp cimport bool as cbool
-from _pele_mc cimport cppConfTest,_Cdef_ConfTest, shared_ptr
+from _pele_mc cimport cppConfTest, _Cdef_ConfTest, shared_ptr
 
 cdef extern from "mcpele/check_spherical_container.h" namespace "mcpele":
     cdef cppclass cppCheckSphericalContainer "mcpele::CheckSphericalContainer":
@@ -8,3 +8,8 @@ cdef extern from "mcpele/check_spherical_container.h" namespace "mcpele":
 cdef extern from "mcpele/check_spherical_container_config.h" namespace "mcpele":
     cdef cppclass cppCheckSphericalContainerConfig "mcpele::CheckSphericalContainerConfig":
         cppCheckSphericalContainerConfig(double) except +
+
+cdef extern from "mcpele/conf_test_OR.h" namespace "mcpele":
+    cdef cppclass cppConfTestOR "mcpele::ConfTestOR":
+        cppConfTestOR() except +
+        void add_test(shared_ptr[cppConfTest]) except +

--- a/mcpele/monte_carlo/_conf_test_cpp.pyx
+++ b/mcpele/monte_carlo/_conf_test_cpp.pyx
@@ -46,3 +46,33 @@ class CheckSphericalContainerConfig(_Cdef_CheckSphericalContainerConfig):
     radius : double
         radius of the spherical container, centered at **0**
     """
+
+#===============================================================================
+# Union of configurational tests
+#===============================================================================
+
+cdef class _Cdef_ConfTestOR(_Cdef_ConfTest):
+    cdef cppConfTestOR* newptr
+    def __cinit__(self):
+        self.thisptr = shared_ptr[cppConfTest](<cppConfTest*> new cppConfTestOR())
+        self.newptr = <cppConfTestOR*> self.thisptr.get()
+    
+    def add_test(self, _Cdef_ConfTest test):
+        """add a conf test to the union
+        
+        Parameters
+        ----------
+        step : :class:`ConfTest`
+            object of class :class:`ConfTest` constructed beforehand
+        """
+        self.newptr.add_test(test.thisptr)
+        
+class ConfTestOR(_Cdef_ConfTestOR):
+    """Creates a union of multiple configurational tests
+    
+    Python interface for c++ ConfTestOR. This configurational
+    test takes multiple conf tests and generates an union,
+    therefore it is sufficient to satisfy one of these
+    subtests to pass their union.
+    
+    """

--- a/source/conf_test_OR.cpp
+++ b/source/conf_test_OR.cpp
@@ -1,0 +1,27 @@
+#include "mcpele/conf_test_OR.h"
+
+namespace mcpele {
+
+ConfTestOR::ConfTestOR(){}
+
+void ConfTestOR::add_test(std::shared_ptr<ConfTest> test_input)
+{
+    m_tests.push_back(test_input);
+    m_tests.swap(m_tests);
+}
+
+bool ConfTestOR::conf_test(pele::Array<double> &trial_coords, MC * mc)
+{
+    if (m_tests.size() == 0) {
+        throw std::runtime_error("ConfTestOR::conf_test: no conf test specified");
+    }
+    for(auto & test : m_tests){
+        bool result = test->conf_test(trial_coords, mc);
+        if (result){
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace mcpele

--- a/source/mcpele/conf_test_OR.h
+++ b/source/mcpele/conf_test_OR.h
@@ -1,0 +1,28 @@
+#ifndef _MCPELE_CONF_TEST_OR_H__
+#define _MCPELE_CONF_TEST_OR_H__
+
+#include <vector>
+#include <random>
+
+#include "mc.h"
+
+namespace mcpele {
+
+/**
+ * Create union of two configurational tests,
+ * it is sufficient for one of them to be true in order to pass the overall test.
+ *
+ */
+class ConfTestOR : public ConfTest {
+private:
+    std::vector<std::shared_ptr<ConfTest> > m_tests;
+public:
+    virtual ~ConfTestOR(){}
+    ConfTestOR();
+    void add_test(std::shared_ptr<ConfTest> test_input);
+    bool conf_test(pele::Array<double> &trial_coords, MC * mc);
+};
+
+} // namespace mcpele
+
+#endif // #ifndef _MCPELE_CONF_TEST_OR_H__

--- a/source/mcpele/record_mean_coord_vector.h
+++ b/source/mcpele/record_mean_coord_vector.h
@@ -1,26 +1,34 @@
-#ifndef _MCPELE_RECORD_MEAN_COORD_VECTOR_H
-#define _MCPELE_RECORD_MEAN_COORD_VECTOR_H
+#ifndef _MCPELE_RECORD_MEAN_COORD_VECTOR_H__
+#define _MCPELE_RECORD_MEAN_COORD_VECTOR_H__
 
 #include "mc.h"
 #include "pele/array.h"
 
 namespace mcpele{
 
-
 class RecordMeanCoordVector : public Action{
 private:
-    pele::Array<double> m_mcv;
-    const size_t m_ndof, m_count, m_eqsteps;
-    double _update_average(double avg, double x);
-    void _update_mean_coord_vector(pele::Array<double> new_coords);
+    pele::Array<double> m_mcv, m_mcv2;
+    const size_t m_ndof, m_eqsteps;
+    size_t m_count;
+    double m_update_average(double avg, double x);
+    void m_update_mean_coord_vector(pele::Array<double> &new_coords);
 public:
-    RecordMeanCoordVector(pele::Array<double> initial_coords, const size_t eqsteps);
-    virtual void action(pele::Array<double> &coords, double energy, bool accepted, MC* mc);
+    RecordMeanCoordVector(const size_t ndof, const size_t eqsteps);
     virtual ~RecordMeanCoordVector(){}
+    virtual void action(pele::Array<double> &coords, double energy, bool accepted, MC* mc);
     pele::Array<double> get_mean_coordinate_vector(){return m_mcv.copy();}
+    pele::Array<double> get_mean2_coordinate_vector(){return m_mcv2.copy();}
+    pele::Array<double> get_variance_coordinate_vector(){
+        pele::Array<double> var = m_mcv2.copy();
+        for(size_t i=0; i<m_ndof; ++i){
+            var[i] -= m_mcv[i]*m_mcv[i];
+        }
+        return var.copy();
+    }
+    size_t get_count(){return m_count;}
 };
-
 
 } //namespace mcpele
 
-#endif //#ifndef _MCPELE_RECORD_MEAN_COORD_VECTOR_H
+#endif //#ifndef _MCPELE_RECORD_MEAN_COORD_VECTOR_H__

--- a/source/mcpele/record_mean_coord_vector.h
+++ b/source/mcpele/record_mean_coord_vector.h
@@ -1,0 +1,26 @@
+#ifndef _MCPELE_RECORD_MEAN_COORD_VECTOR_H
+#define _MCPELE_RECORD_MEAN_COORD_VECTOR_H
+
+#include "mc.h"
+#include "pele/array.h"
+
+namespace mcpele{
+
+
+class RecordMeanCoordVector : public Action{
+private:
+    pele::Array<double> m_mcv;
+    const size_t m_ndof, m_count, m_eqsteps;
+    double _update_average(double avg, double x);
+    void _update_mean_coord_vector(pele::Array<double> new_coords);
+public:
+    RecordMeanCoordVector(pele::Array<double> initial_coords, const size_t eqsteps);
+    virtual void action(pele::Array<double> &coords, double energy, bool accepted, MC* mc);
+    virtual ~RecordMeanCoordVector(){}
+    pele::Array<double> get_mean_coordinate_vector(){return m_mcv.copy();}
+};
+
+
+} //namespace mcpele
+
+#endif //#ifndef _MCPELE_RECORD_MEAN_COORD_VECTOR_H

--- a/source/record_mean_coord_vector.cpp
+++ b/source/record_mean_coord_vector.cpp
@@ -1,0 +1,38 @@
+#include "mcpele/record_mean_coord_vector.h"
+
+namespace mcpele{
+
+RecordMeanCoordVector::RecordMeanCoordVector(pele::Array<double> initial_coordinates, const size_t eqsteps)
+    : m_mcv(initial_coordinates.size(),0),
+      m_ndof(initial_coordinates.size()),
+      m_count(0),
+      m_eqsteps(eqsteps)
+    {}
+
+double RecordMeanCoordVector::_update_average(double avg, double x)
+{
+    double n = m_count;
+    return (avg * n + x) / (n+1);
+}
+
+void RecordMeanCoordVector::_update_mean_coord_vector(pele::Array<double> new_coords){
+    for(size_t i=0; i<m_ndof; ++i){
+        m_mcv[i] = this->_updade_average(m_mcv[i], new_coords[i]);
+    }
+    ++m_count;
+}
+
+void RecordMeanCoordVector::action(Array<double> &coords, double energy, bool accepted, MC* mc)
+{
+    size_t count = mc->get_iterations_count();
+    if (count > m_eqsteps){
+        if (accepted){
+            this->_update_mean_coord_vector(coords);
+        }
+        else{
+            this->_update_mean_coord_vector(m_mcv);
+        }
+    }
+}
+
+} //namespace mcpele

--- a/source/record_mean_coord_vector.cpp
+++ b/source/record_mean_coord_vector.cpp
@@ -1,36 +1,47 @@
+#include <stdexcept>
 #include "mcpele/record_mean_coord_vector.h"
 
 namespace mcpele{
-
-RecordMeanCoordVector::RecordMeanCoordVector(pele::Array<double> initial_coordinates, const size_t eqsteps)
-    : m_mcv(initial_coordinates.size(),0),
-      m_ndof(initial_coordinates.size()),
+/*
+ * m_mcv mean coordinate vector
+ * m_mcv2 element wise square mean coordinate vector, useful to compute the variance in each coordinate
+ * */
+RecordMeanCoordVector::RecordMeanCoordVector(const size_t ndof, const size_t eqsteps)
+    : m_mcv(ndof,0), //it is important that m_mcv is initialised to vec{0} for the first update step to work correctly
+      m_mcv2(ndof,0),
+      m_ndof(ndof),
       m_count(0),
       m_eqsteps(eqsteps)
     {}
 
-double RecordMeanCoordVector::_update_average(double avg, double x)
+double RecordMeanCoordVector::m_update_average(double avg, double x)
 {
     double n = m_count;
     return (avg * n + x) / (n+1);
 }
 
-void RecordMeanCoordVector::_update_mean_coord_vector(pele::Array<double> new_coords){
+void RecordMeanCoordVector::m_update_mean_coord_vector(pele::Array<double> &new_coords){
     for(size_t i=0; i<m_ndof; ++i){
-        m_mcv[i] = this->_updade_average(m_mcv[i], new_coords[i]);
+        double newx = new_coords[i];
+        m_mcv[i] = this->m_update_average(m_mcv[i], newx);
+        m_mcv2[i] = this->m_update_average(m_mcv2[i], newx*newx);
     }
     ++m_count;
 }
 
-void RecordMeanCoordVector::action(Array<double> &coords, double energy, bool accepted, MC* mc)
+void RecordMeanCoordVector::action(pele::Array<double> &coords, double energy, bool accepted, MC* mc)
 {
+
+    if (coords.size() != m_ndof) {
+        throw std::runtime_error("RecordMeanCoordVector::action: ndof and new coords have different size");
+    }
     size_t count = mc->get_iterations_count();
     if (count > m_eqsteps){
         if (accepted){
-            this->_update_mean_coord_vector(coords);
+            this->m_update_mean_coord_vector(coords);
         }
         else{
-            this->_update_mean_coord_vector(m_mcv);
+            this->m_update_mean_coord_vector(m_mcv);
         }
     }
 }


### PR DESCRIPTION
this is a simple addition that allows to create the union of multiple configurational tests. For instance it allows to test whether a walker is within the union of two hyperspheres or hypercubes.